### PR TITLE
fixes to ipset_sync

### DIFF
--- a/files/ipset_sync
+++ b/files/ipset_sync
@@ -52,7 +52,7 @@ function construct_ipset_dump() {
   # recreate the dump format from config files manually
   (
     cat "${f_header}";
-    cat "${f_content}" | grep -v '^[ ]*#' | sed -re "s/(.*)/add ${id} \\1/" | LC_ALL=C sort
+    cat "${f_content}" | sed -e '/^create/d' -e '/^[ ]*#/d' -e 's/#.*$//g' -e'/^$/d'  -re "s/(.*)/add ${id} \\1/" | LC_ALL=C sort | LC_ALL=C uniq
   )
 }
 

--- a/spec/classes/ipset_spec.rb
+++ b/spec/classes/ipset_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'ipset' do
+ it do
+   should contain_package('ipset')
+ end
+ it 'drops ipset_init' do
+   should contain_file('/usr/local/sbin/ipset_init').
+ end
+ it 'drops ipset_sync' do
+   should contain_file('/usr/local/sbin/ipset_sync').
+ end
+ it 'drops ipset.conf' do
+   should contain_file('/etc/init/ipset.conf').
+ end
+
+end


### PR DESCRIPTION
Fixes to ipset_sync to: 

* ignore blank lines
* ignore comments both single line and at the end of a line
* ignore duplicate IPs
* ignore extra create line.

Also added a trivial spec for unit tests - note this only applies to RH6 and similar, will need changes for RH7, etc.

@mighq 