### PR TITLE
fix ipset_sync not seeing return value of diff (3635959)

### DIFF
--- a/files/ipset_sync
+++ b/files/ipset_sync
@@ -110,6 +110,7 @@ function ipset_insync_common() {
   # compare configured and runtime config
   tf=$(mktemp)
   diff <(get_ipset_dump ${id} | grep ^${pfx}) <(construct_ipset_dump ${id} | grep ^${pfx}) > ${tf}
+  local ret=$?
 
   # show differences, if requested by CLI option
   if [ -n "${verbose_output}" ] && [ ${verbose_output} -gt 0 ]; then
@@ -118,6 +119,7 @@ function ipset_insync_common() {
 
   # cleanup
   rm -f "${tf}"
+  return ${ret}
 }
 
 


### PR DESCRIPTION
Commit 3635959badf19cd7fc0d71c348201de6a63a91e7 added commands after the diff in ipset_insync_common that compares in-memory set to on-disk set.  Return value of diff is no longer seen, which results in ipset_insync_common returning 0 even when there is a difference.