### PR TITLE
update set short-circuiting

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,13 @@ define ipset (
     }
 
     # content
-    if $set =~ /^puppet:\/\// {
+    if is_array($set) {
+      # create file with ipset, one record per line
+      file { "${::ipset::params::config_path}/${title}.set":
+        ensure  => present,
+        content => inline_template('<%= (@set.map { |i| i.to_s }).join("\n") %>'),
+      }
+    } elsif $set =~ /^puppet:\/\// {
       # passed as puppet file
       file { "${::ipset::params::config_path}/${title}.set":
         ensure => present,
@@ -40,12 +46,6 @@ define ipset (
       file { "${::ipset::params::config_path}/${title}.set":
         ensure => present,
         source => regsubst($set, '^.{7}', ''),
-      }
-    } elsif is_array($set) {
-      # create file with ipset, one record per line
-      file { "${::ipset::params::config_path}/${title}.set":
-        ensure  => present,
-        content => inline_template('<%= (@set.map { |i| i.to_s }).join("\n") %>'),
       }
     } else {
       # passed directly as content string (from template for example)


### PR DESCRIPTION
The future parser doesn't like comparing an Array to a string, so we need to change the logic short circuiting to test for the variable being an array first, not last.