### PR TITLE
FIX: resource order - /etc/init.d/ipset: No such file or directory 

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,6 +29,7 @@ class ipset::install {
       exec { 'ipset_disable_distro':
         command => "/bin/bash -c '/etc/init.d/ipset stop && /sbin/chkconfig ipset off'",
         unless  => "/bin/bash -c '/sbin/chkconfig | /bin/grep ipset | /bin/grep -qv :on'",
+        require => Package[$::ipset::params::package],
       }
       ->
       # upstart starter


### PR DESCRIPTION
This fixes the following error:

```
Error: /Stage[main]/Ipset::Install/Exec[ipset_disable_distro]/returns: change from notrun to 0 failed: /bin/bash: /etc/init.d/ipset: No such file or directory
```
fixed by requiring package prior to exec statement.
