### PR TITLE
Fix issues with defaults options and some types

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,17 @@ define ipset (
     'maxelem'  => '65536',
   }
 
-  $actual_options = merge($default_options, $options)
+  if $type == 'hash:mac' {
+    # family option is not available for type hash:mac
+    $_default_options = delete($default_options, 'family')
+  } elsif $type !~ /^hash:/ {
+    # family, hashsize and maxelem options are available only for hash:* (except hash:mac)
+    $_default_options = delete($default_options, ['family','hashsize','maxelem'])
+  } else {
+    $_default_options = $default_options
+  }
+
+  $actual_options = merge($_default_options, $options)
 
   if $ensure == 'present' {
     # assert "present" target


### PR DESCRIPTION
Default option 'family' is supported only by hash sets except for
hash:mac and default options 'hashsize' and 'maxelem' are supported only
by hash sets. This patch deletes from default_options theses options,
depending to the type name.

This fixes issues when working with some types
```
# ipset create foo bitmap:port family inet hashsize 1024 maxelem 6553
ipset v6.12.1: Unknown argument: `family'
Try `ipset help' for more information.
```
According to the [man page](http://ipset.netfilter.org/ipset.man.html)

> ### family { inet | inet6 }
> This parameter is valid for the create command of all **hash** type sets except for **hash:mac**.
> ### hashsize
> This parameter is valid for the create command of all **hash** type sets.
> ### maxelem
> This parameter is valid for the create command of all **hash** type sets.
