### PR TITLE
Ignore hashsize to avoid conflicts on large sets

### DIFF
--- a/files/ipset_sync
+++ b/files/ipset_sync
@@ -115,7 +115,10 @@ function ipset_insync_common() {
 
   # compare configured and runtime config
   tf=$(mktemp)
-  diff <(get_ipset_dump ${id} | grep ^${pfx}) <(construct_ipset_dump ${id} | grep ^${pfx}) > ${tf}
+  diff \
+    <(get_ipset_dump ${id} | grep ^${pfx} | sed 's/hashsize [0-9]\+ //g') \
+    <(construct_ipset_dump ${id} | grep ^${pfx} | sed 's/hashsize [0-9]\+ //g') \
+    > ${tf}
   local rv=$?
 
   # show differences, if requested by CLI option


### PR DESCRIPTION
Hello,

I got the issue described in #14 and the workaround was not working for me as I have already in place ipset with large sets.
Here is my fix proposal.

Edouard