### PR TITLE
Ensure all file resources are files

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ define ipset (
 
     # header
     file { "${::ipset::params::config_path}/${title}.hdr":
+      ensure  => file,
       content => "create ${title} ${type} ${opt_string}\n",
       notify  => Exec["sync_ipset_${title}"],
     }
@@ -35,25 +36,25 @@ define ipset (
     if is_array($set) {
       # create file with ipset, one record per line
       file { "${::ipset::params::config_path}/${title}.set":
-        ensure  => present,
+        ensure  => file,
         content => inline_template('<%= (@set.map { |i| i.to_s }).join("\n") %>'),
       }
     } elsif $set =~ /^puppet:\/\// {
       # passed as puppet file
       file { "${::ipset::params::config_path}/${title}.set":
-        ensure => present,
+        ensure => file,
         source => $set,
       }
     } elsif $set =~ /^file:\/\// {
       # passed as target node file
       file { "${::ipset::params::config_path}/${title}.set":
-        ensure => present,
+        ensure => file,
         source => regsubst($set, '^.{7}', ''),
       }
     } else {
       # passed directly as content string (from template for example)
       file { "${::ipset::params::config_path}/${title}.set":
-        ensure  => present,
+        ensure  => file,
         content => $set,
       }
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,6 +40,7 @@ class ipset::install {
       ->
       # upstart starter
       file { '/etc/init/ipset.conf':
+        ensure  => file,
         owner   => 'root',
         group   => 'root',
         mode    => '0644',
@@ -59,6 +60,7 @@ class ipset::install {
 
       # systemd service definition, there is no script in COS7
       file { '/usr/lib/systemd/system/ipset.service':
+        ensure  => file,
         owner   => 'root',
         group   => 'root',
         mode    => '0644',

--- a/manifests/install/helper_script.pp
+++ b/manifests/install/helper_script.pp
@@ -1,5 +1,6 @@
 define ipset::install::helper_script () {
   file { "/usr/local/sbin/${title}":
+    ensure => file,
     owner  => 'root',
     group  => 'root',
     mode   => '0754',


### PR DESCRIPTION
When ensure is not set, file resources inherits from the higher level
defaults.

When "ensure" defaults to "directory", it causes weird issues:
* The systemd service is a directory
* The entries in /etc/ipset are directories

Fix #20