### PR TITLE
Add systemctl daemon-reload after the service file is updated

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -65,6 +65,11 @@ class ipset::install {
         content => template("${module_name}/init.systemd.erb"),
       }
       ~>
+      exec { 'ipset systemctl daemon-reload':
+        command     => '/bin/systemctl daemon-reload',
+        refreshonly => true,
+      }
+      ~>
       # systemd service autostart
       service { 'ipset':
         ensure => 'running',


### PR DESCRIPTION
Without a systemctl daemon-reload the ipset service will fail to launch until installing some other package does it for you.