### PR TITLE
Replace deprecated is_array() function

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,7 @@ define ipset (
     }
 
     # content
-    if is_array($set) {
+    if $set =~ Array {
       # create file with ipset, one record per line
       file { "${::ipset::params::config_path}/${title}.set":
         ensure  => present,
@@ -58,7 +58,7 @@ define ipset (
       }
     }
 
-    # add switch to script, if we 
+    # add switch to script, if we
     if $ignore_contents {
       $ignore_contents_opt = ' -n'
     } else {


### PR DESCRIPTION
Without this patch we're getting warnings like these from Puppet 4.8.2:
```
Warning: This method is deprecated, please use match expressions with Stdlib::Compat::Array instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions. at ["/etc/puppetlabs/code/environments/production/modules/ipset/manifests/init.pp", 32]:
   (at /etc/puppetlabs/code/librarian/modules/stdlib/lib/puppet/functions/deprecation.rb:25:in `deprecation')
```

I have tested this and it works for me.

What can I do to help you get this merged?

  Regards /Johan